### PR TITLE
Enable sass imports from npm modules

### DIFF
--- a/gulp/tasks/styles.js
+++ b/gulp/tasks/styles.js
@@ -9,7 +9,8 @@ module.exports = function(gulp, gutil, plugins, browserSync){
 
     var env = require('../settings/config').environment.production,
         path = require('../settings/paths'),
-        error = require('../settings/error-handler');
+        error = require('../settings/error-handler'),
+        npmSassImporter = require('npm-sass').importer;
 
     if ( gutil.env.dev === true ) {
         env = require('../settings/config').environment.development
@@ -36,6 +37,7 @@ module.exports = function(gulp, gutil, plugins, browserSync){
                 outputStyle : 'expanded',
                 sourceComments : 'normal', // none|normal|map
                 includePaths : ['scss'],
+                importer: npmSassImporter,
                 errLogToConsole : true
             }))
             .on('error', error.handleError)

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "gulp-svg2png": "^0.3.0",
     "gulp-uglify": "^1.2.0",
     "gulp-util": "^3.0",
+    "npm-sass": "^1.1.0",
     "yargs": "^3.10.0"
   }
 }


### PR DESCRIPTION
Opening this PR so that we can import Sass includes from npm modules without having to store dependencies in the same git repo.
